### PR TITLE
feat: Adds support for building docker images for ARM64

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,49 +1,65 @@
 name: Build and Push Docker Image to GHCR
 
 on:
-    push:
-        branches:
-            - main
-    release:
-        types: [published]
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
 
 env:
-    REGISTRY: ghcr.io
-    IMAGE_NAME: stannnnn/jelly-music-app
+  REGISTRY: ghcr.io
+  PLATFORMS: linux/amd64,linux/arm64
+  APP_IMAGE_NAME: jelly-music-app
 
 jobs:
-    build-and-push:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
-            attestations: write
-            id-token: write
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Log in to GHCR
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-            - name: Set Docker image tags
-              id: vars
-              run: |
-                  if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-                    VERSION_TAG="${GITHUB_REF##*/}"
-                    echo "TAGS=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION_TAG},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_ENV
-                  elif [[ "${GITHUB_REF##*/}" == "main" ]]; then
-                    echo "TAGS=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main" >> $GITHUB_ENV
-                  fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-            - name: Build and push Docker image
-              uses: docker/build-push-action@v6
-              with:
-                  context: .
-                  push: true
-                  tags: ${{ env.TAGS }}
+      - name: Set image name
+        run: |
+          ACTOR_LC=$(echo "${GITHUB_ACTOR}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME="${ACTOR_LC}/${APP_IMAGE_NAME}"
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Docker image tags
+        id: vars
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            VERSION_TAG="${GITHUB_REF##*/}"
+            TAGS="${REGISTRY}/${IMAGE_NAME}:${VERSION_TAG},${REGISTRY}/${IMAGE_NAME}:latest"
+          else
+            TAGS="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
+          fi
+          echo "TAGS=${TAGS}" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        if: env.TAGS != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.TAGS }}
+          platforms: ${{ env.PLATFORMS }}


### PR DESCRIPTION
Modifies GitHub docker build action to build images for both amd64 and arm64 to solve #24.

Alters build process to use current user (lowercase) + specified ENV var for image name, and makes it build any branch specified on `on.push.branches` (useful for testing).

Due to manifest attestation metadata, an extra `unknown/unknown` target platform will be shown on the GitHub UI. [This is only a UI issue](https://github.com/orgs/community/discussions/45969), and should not affect in any way the usage of the images. Provenance metadata may be useful in some instances, so I do not think removing it is worth it.

![image](https://github.com/user-attachments/assets/e68eb28a-7d76-470a-afcc-5657a086ef5e)
The above is the only effect of this metadata.