### PR TITLE
fix: Crops instead of stretches "now playing" images

### DIFF
--- a/src/pages/NowPlaying.css
+++ b/src/pages/NowPlaying.css
@@ -136,6 +136,7 @@
     max-width: 100%;
     max-height: 100%;
     aspect-ratio: 1 / 1;
+    object-fit: cover;
 }
 
 .now-playing > .ui > .playing-content > .playing-artwork > .thumbnail > .fallback-thumbnail {
@@ -147,6 +148,7 @@
     max-width: 100%;
     max-height: 100%;
     aspect-ratio: 1 / 1;
+    object-fit: cover;
     background-color: var(--bg-color-tertiary);
 }
 


### PR DESCRIPTION
Uses CSS `object-fit: cover;` to fix non-square song art scaling on "now playing", cropping the images instead:

<img width="426" height="652" alt="image" src="https://github.com/user-attachments/assets/e5e94ca3-52d8-4c72-9822-9e282e91cc81" />

to:

<img width="436" height="668" alt="image" src="https://github.com/user-attachments/assets/74423d09-01b1-41a0-bb92-c68c699e7e0b" />
