### PR TITLE
fix: Use repository owner instead of actor

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Set image name
         run: |
-          ACTOR_LC=$(echo "${GITHUB_ACTOR}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_NAME="${ACTOR_LC}/${APP_IMAGE_NAME}"
+          OWNER_LC=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME="${OWNER_LC}/${APP_IMAGE_NAME}"
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
 
       - name: Log in to GHCR


### PR DESCRIPTION
Changes Docker build flow to use the repository owner instead of the actor for package names.

This should fix the build action. So you do not have to merge this and add another fix release, I think @Stannnnn manually retriggering the job may make it work.

The issue was @Simonh2o creating that release.