### PR TITLE
fix: Adds some information on desktop bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 
-deploy.sh
-release
+# Build files
+release/

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,6 +29,15 @@
     "bundle": {
         "active": true,
         "targets": "all",
-        "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"]
+        "shortDescription": "A lightweight & elegant music interface for Jellyfin",
+        "longDescription": " A lightweight & elegant music interface for Jellyfin. Made to be intuitive and minimal with great attention to detail, a clutter-free web app centered on music playback. Using the Jellyfin API, it provides seamless access to your personal music library.",
+        "category": "Music",
+        "icon": [
+            "icons/32x32.png",
+            "icons/128x128.png",
+            "icons/128x128@2x.png",
+            "icons/icon.icns",
+            "icons/icon.ico"
+        ]
     }
 }


### PR DESCRIPTION
Adds some missing information for bundlers on the Tauri config:

 - Adds short description for .desktop comments
 - Adds long description from README
 - Adds category for proper categorization