### PR TITLE
feat: Add simple word-by-word lyrics display

### DIFF
--- a/src/pages/Lyrics.css
+++ b/src/pages/Lyrics.css
@@ -32,6 +32,10 @@
     color: var(--brand-color);
 }
 
+.lyrics-page.synced .lyric-word.active {
+    filter: brightness(0.6);
+}
+
 .lyrics-page.synced > .lyrics-line:hover {
     background-color: var(--bg-color-secondary);
 }

--- a/src/pages/Lyrics.tsx
+++ b/src/pages/Lyrics.tsx
@@ -3,12 +3,16 @@ import { useLocation } from 'react-router-dom'
 import { Loader } from '../components/Loader'
 import { usePlaybackContext } from '../context/PlaybackContext/PlaybackContext'
 import './Lyrics.css'
+import { LyricLine } from '@jellyfin/sdk/lib/generated-client'
+
+type LyricLineCue = { Position: number; EndPosition: number; Start: number; End: number }
+type LyricLineData = LyricLine & { Cues?: LyricLineCue[] }
 
 export const Lyrics = () => {
     const playback = usePlaybackContext()
     const audio = playback.audioRef as HTMLAudioElement | undefined
 
-    const [currentTime, setCurrentTime] = useState<number | null>(null)
+    const [currentTimeMs, setCurrentTimeMs] = useState<number | null>(null)
     const lineRefs = useRef<Array<HTMLDivElement | null>>([])
 
     const location = useLocation()
@@ -33,31 +37,50 @@ export const Lyrics = () => {
         return (hours > 0 ? `${hh}:` : '') + `${mm}:${ss}.${cc}`
     }
 
-    const timeDiff = (startTicks: number | null, timeSecs: number | null) => {
-        return (startTicks || 0) / 10000 - (timeSecs || 0) * 1000
+    const timeDiff = (startTicks: number | null, timeMs: number | null) => {
+        return (startTicks || 0) / 10000 - (timeMs || 0)
     }
 
-    const lyrics = playback.currentTrackLyrics?.Lyrics
+    const lyrics = playback.currentTrackLyrics?.Lyrics as unknown as LyricLineData[] | undefined
+
+    // Builds a list of relevant times to update currentTime
+    const eventTimesMs = useMemo(() => {
+        const rawTimes: number[] = []
+
+        lyrics?.forEach(line => {
+            if (typeof line.Start === 'number') rawTimes.push(line.Start / 10000)
+
+            line.Cues?.forEach(cue => {
+                if (typeof cue.Start === 'number') rawTimes.push(cue.Start / 10000)
+                if (typeof cue.End === 'number') rawTimes.push(cue.End / 10000)
+            })
+        })
+
+        // Deduplicate Times and sort
+        return Array.from(new Set(rawTimes).values()).sort()
+    }, [lyrics])
+
+    const nextEventTimeMs = useMemo(() => {
+        return eventTimesMs.find(t => t > (currentTimeMs || 0))
+    }, [currentTimeMs, eventTimesMs])
 
     const isSynced = useMemo(() => {
         if (!lyrics || lyrics[0].Start === null || lyrics[0].Start === undefined) return false
         return true
     }, [lyrics])
 
+    const isWordByWord = useMemo(() => {
+        if (!lyrics || lyrics[0].Cues === null || lyrics[0].Cues?.length === 0) return false
+        return true
+    }, [lyrics])
+
     const currentLineIndex = useMemo(() => {
         if (!audio || !lyrics) return -1
 
-        const index = lyrics.findIndex(line => timeDiff(line?.Start || 0, currentTime) > 0)
+        const index = lyrics.findIndex(line => timeDiff(line?.Start || 0, currentTimeMs) > 0)
 
         return lyrics ? (index >= 0 ? index - 1 : lyrics.length - 1) : -1
-    }, [audio, lyrics, currentTime])
-
-    const nextLineStart = useMemo(() => {
-        if (!audio || !lyrics) return -1
-
-        if (lyrics && lyrics[currentLineIndex + 1]) return lyrics[currentLineIndex + 1]?.Start || 0
-        return 0
-    }, [audio, lyrics, currentLineIndex])
+    }, [audio, lyrics, currentTimeMs])
 
     // Uses timeout for precise lyrics timing
     //  - Necessary because audio time updates happen every 200ms or so; too slow
@@ -70,18 +93,20 @@ export const Lyrics = () => {
     }
 
     useEffect(() => {
-        const millis = timeDiff(nextLineStart, currentTime)
+        if (nextEventTimeMs === undefined || currentTimeMs === null) return
+
+        const millis = nextEventTimeMs - currentTimeMs + 1
 
         if (millis > 0) {
             // Sets timeout to diff from next line and last currentTime update
             nextLineTimeout.current = setTimeout(() => {
-                if (currentTime && playback.isPlaying) setCurrentTime(currentTime + millis / 1000)
+                if (currentTimeMs && playback.isPlaying) setCurrentTimeMs(nextEventTimeMs + 1)
                 clearNextLineTimeout()
             }, millis)
         }
 
         return clearNextLineTimeout
-    }, [playback.isPlaying, currentTime, currentLineIndex, nextLineStart])
+    }, [playback.isPlaying, currentTimeMs, currentLineIndex, nextEventTimeMs])
 
     useEffect(() => {
         clearNextLineTimeout()
@@ -92,11 +117,11 @@ export const Lyrics = () => {
 
         const updateCurrentTime = () => {
             if (!audio.duration) {
-                setCurrentTime(null)
+                setCurrentTimeMs(null)
                 return
             }
 
-            setCurrentTime(audio?.currentTime || 0)
+            setCurrentTimeMs(audio?.currentTime * 1000 || 0)
         }
 
         audio.addEventListener('timeupdate', updateCurrentTime)
@@ -134,12 +159,34 @@ export const Lyrics = () => {
             const audio = playback.audioRef as HTMLAudioElement | undefined
 
             if (audio && lyrics && lyrics[index]?.Start) {
-                setCurrentTime(lyrics[index].Start / 10000000)
+                setCurrentTimeMs(lyrics[index].Start / 10000)
                 audio.currentTime = lyrics[index].Start / 10000000
                 if (isSynced) scrollToActiveLine(index)
             }
         },
         [isSynced, lyrics, playback.audioRef, scrollToActiveLine]
+    )
+
+    const displayedLyricsLine = useCallback(
+        (line: LyricLineData) => {
+            if (!isWordByWord) return line.Text
+
+            const cues = line.Cues ?? []
+            if (cues.length === 0) return line.Text
+
+            return cues.map((cue, i) => (
+                <span
+                    key={`cue-${line.Start}-${i}`}
+                    className={'lyric-word' + (currentTimeMs && cue.Start / 10000 <= currentTimeMs ? ' active' : '')}
+                    data-start={cue.Start ?? undefined}
+                    data-end={cue.End ?? undefined}
+                >
+                    {line.Text?.slice(cue.Position, cue.EndPosition)}
+                    {i < cues.length - 1 ? ' ' : ''}
+                </span>
+            ))
+        },
+        [isWordByWord, currentTimeMs]
     )
 
     const displayedLines = useMemo(() => {
@@ -160,13 +207,16 @@ export const Lyrics = () => {
                             {line.Start !== null && line.Start !== undefined && tickToTimeString(line.Start)}
                         </div>
                     ) : null}
-                    <div className={'text' + (playback.centeredLyrics ? ' centered' : '')}>{line.Text}</div>
+                    <div className={'text' + (playback.centeredLyrics ? ' centered' : '')}>
+                        {displayedLyricsLine(line)}
+                    </div>
                 </div>
             )) || null
         )
     }, [
         playback.currentTrack,
         goToLine,
+        displayedLyricsLine,
         playback.lyricsTimestamps,
         playback.centeredLyrics,
         lyrics,


### PR DESCRIPTION
Added word-by-word lyrics support. You can now load eLRC lyrics to Jellyfin and it will use those to sync word-by-word lyrics (karaoke style). Jellyfin has supported this type of lyrics for a while now, but not on its own interface. You can still upload eLRC files normally.

I am currently using a simple brightness filter for current/past lyrics and have updated the lyrics internal clock to use milliseconds instead of seconds.

[2026-01-04 18-59-38.webm](https://github.com/user-attachments/assets/c600699a-0ad1-4814-9cd3-b62f8237dfdc)
