### PR TITLE
fix: Fixes word spacing for non-spaced language lyrics.

### DIFF
--- a/src/pages/Lyrics.css
+++ b/src/pages/Lyrics.css
@@ -201,7 +201,6 @@
     display: flex;
     flex-wrap: wrap;
     row-gap: 2px;
-    column-gap: 0.475rem;
 }
 
 /* Because of flex from above */
@@ -262,6 +261,11 @@
 /* Current word uses animated --p (set by rAF) */
 .lyrics-page.synced > .lyrics-line.active > .text > .lyric-word.current {
     --base-alpha: 0.7;
+}
+
+/* Add extra space for spaced words */
+.lyrics-page.synced > .lyrics-line > .text > .lyric-word.space {
+    margin-right: 0.475rem;
 }
 
 /* Past words in non-active lines */

--- a/src/pages/Lyrics.tsx
+++ b/src/pages/Lyrics.tsx
@@ -180,7 +180,7 @@ export const Lyrics = () => {
                 return (
                     <span
                         key={`cue-${line.Start}-${i}`}
-                        className={'lyric-word' + (isPast ? ' active' : '') + (isCurrent ? ' current' : '')}
+                        className={'lyric-word' + (isPast ? ' active' : '') + (isCurrent ? ' current' : '') + (chunk.endsWith(' ') ? ' space' : '')}
                         data-start={startMs}
                         data-end={endMs}
                         data-text={chunk}


### PR DESCRIPTION
Some languages do not use spaces for word separation (japanese, chinese, etc). Here I change the added word gap so we explicitly style spaced words instead of adding a global gap between words when not applicable.

**It still adds spaces where necessary**:
Before, spaces:
<img width="664" height="513" alt="image" src="https://github.com/user-attachments/assets/57609284-a6da-4e1a-a2dc-1f34af4e859f" />
After, spaces:
<img width="591" height="380" alt="image" src="https://github.com/user-attachments/assets/5e48ac89-1230-4f9c-8128-b9fe4589e565" />
<img width="449" height="316" alt="image" src="https://github.com/user-attachments/assets/fa81d898-7d19-45fa-a487-22d290a9a395" />

**It does not add spacing when no space is expected**:
Before, no spaces:
<img width="569" height="497" alt="image" src="https://github.com/user-attachments/assets/3a02ed6a-b2a8-432e-97a4-6e9e08e50300" />
After, no spaces:
<img width="540" height="303" alt="image" src="https://github.com/user-attachments/assets/9e527443-5135-4a69-858c-3d8be4436987" />
<img width="492" height="337" alt="image" src="https://github.com/user-attachments/assets/708f99d9-246b-40b8-9631-c2813703b157" />

It also fixes lyrics for eLRCs with finer granularity than words

Before a line like

```
[00:13.20] <00:13.20> Thisisa<00:13.56>longword <00:13.80> with <00:14.20> multiple <00:14.72> timings <00:15.01>
```

Would render as:
```
Thisisa longword with multiple timings
```

Now it renders properly as:
```
Thisisalongword with multiple timings
```